### PR TITLE
Add explicit Webrick dependency

### DIFF
--- a/capistrano-s3.gemspec
+++ b/capistrano-s3.gemspec
@@ -33,5 +33,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "aws-sdk",    "~> 2.6"
   s.add_runtime_dependency "capistrano", ">= 2"
   s.add_runtime_dependency "mime-types"
+  s.add_runtime_dependency "webrick" # Temporary, while 'aws-sdk' is < 3.0
+
   s.metadata["rubygems_mfa_required"] = "true"
 end


### PR DESCRIPTION
Required for Ruby 3.0+ support while having 'aws-sdk' at 2.x.

Fixes: #61 